### PR TITLE
Fix text property not being counted properly

### DIFF
--- a/jsonconvert.py
+++ b/jsonconvert.py
@@ -194,7 +194,7 @@ def reader(story):
 
         if d['attributes'].get('text'):
             if COUNTER_FLAG:
-                counter += len(content.split()) if story.lang == 'en_US' else len(content)
+                counter += len(d['attributes']['text'].split()) if story.lang == 'en_US' else len(d['attributes']['text'])
         
         
         rawlist.append(d)

--- a/jsonconvert.py
+++ b/jsonconvert.py
@@ -122,7 +122,7 @@ def reader(story):
             options = d['attributes']['options'].split(';')
             if COUNTER_FLAG:
                 for option in options:
-                    counter += len(content.split()) if story.lang == 'en_US' else len(content)
+                    counter += len(option.split()) if story.lang == 'en_US' else len(option)
             values = [f"option{value}" for value in d['attributes']['values'].split(';')]
             if OPTIONTRACE:
                 for idx,value in enumerate(values[:len(options)]):


### PR DESCRIPTION
Previously, it is trying to find the length of content in `[prop(attr1=value1, attr2=value2, ...)] content`  
But all lines with `text="..."` have the text as `value`, not as `content`, so the `value` length should be counted instead. No lines with a `text="..."` property also include `content`, so before this fix all `text="..."` lines were not counted in wordcount.  

For example, in en_US Episode 14 is currently listed as 93221 words. With this fix it will be 97937.