### PR TITLE
feat: Add null check for story info and batch export feature

### DIFF
--- a/codespace.sh
+++ b/codespace.sh
@@ -14,10 +14,32 @@ fi
 
 echo -e "Current Server: \033[1;33m $server\033[0m"
 python xlsxconvert.py -E -L $server
-echo -e "\033[1;32m Enter the index of the event you want to export: \033[0m"
+index_count=$(SERVER="$server" python - <<'PY'
+from pathlib import Path
+import os
+import func
+
+server = os.environ["SERVER"]
+data_dir = Path('ArknightsGameData')
+print(len(func.getAct(data_dir, server)) + len(func.getMainline(data_dir, server)))
+PY
+)
+echo -e "\033[1;32m Available indexes: $index_count \033[0m"
+echo -e "\033[1;32m Enter the index of the event you want to export, or type \033[1;33mall\033[0m\033[1;32m to export every index: \033[0m"
 
 read event
-python xlsxconvert.py -e $event -i -L $server
+if [ "$event" = "all" ]; then
+    if [ "$index_count" -gt 0 ]; then
+        for i in $(seq 0 $((index_count - 1))); do
+            python xlsxconvert.py -e $i -i -L $server
+        done
+        echo -e "\033[1;32m All events exported. \033[0m"
+    else
+        echo -e "\033[1;31m No indexes available to export. \033[0m"
+    fi
+else
+    python xlsxconvert.py -e $event -i -L $server
+fi
 
 # tell user how to download the file in codespace
 echo -e "\033[1;32m To download the file in code space. Right click the file and select "download"  \033[0m"

--- a/xlsxconvert.py
+++ b/xlsxconvert.py
@@ -321,7 +321,7 @@ if __name__ == "__main__":
                 cell.font = bold
 
             for idx, story in enumerate(event):
-                if infoFlag:
+                if infoFlag and story.storyInfo is not None:
                     with open(story.storyInfo, encoding='utf-8') as storyInfoFile:
                         storyInfo = storyInfoFile.read()
                 else:


### PR DESCRIPTION
## Changes

### 1. Fix: Handle null storyInfo in xlsx conversion (xlsxconvert.py:324)
- Added null check before attempting to open story info files
- Prevents TypeError when processing stories without info files
- Fixes issue with main_14 chapter 14-22 'Conclusion ~Final Stage~'
- All 41 stories in main_14 now process correctly

### 2. Feature: Batch export capability (codespace.sh)
- Added dynamic index count calculation
- New 'all' option to export every available event in sequence
- Shows available index count to user
- Improved user prompt with better guidance
- To-do: error handling for unavailable indexes*

## Testing
- Tested main_14 conversion: Successfully generates 588 KB xlsx file (using en_US data)
- Tested with GitHub Copilot CLI
- Verified all 41 stories process correctly (40 with info, 1 without)

## Details
All code changes were implemented and tested using GitHub Copilot CLI.
To-do: *  If one or more executions of the loop inside the .sh script fails it proceeds with the next execution not registering the error. The en gamedata used does not contain the files for the stories act13mini and act24side, respectively index #60 and #24, for unknown reasons.
The dataset used was the one available at https://github.com/ArknightsAssets/ArknightsGamedata.